### PR TITLE
set BIND_ADDRESS env on Heroku button

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
     "AWS_SECRET_ACCESS_KEY" : "Your AWS Secret Key Here",
     "ENDPOINT" : "ES Endpoint (ex: my-endpoint.region-1.es.amazonaws.com)",
     "USER" : "HTTP Auth Username",
-    "PASSWORD" : "HTTP Auth Password"
+    "PASSWORD" : "HTTP Auth Password",
+    "BIND_ADDRESS" : "0.0.0.0"
   }
 }


### PR DESCRIPTION
The Heroku deployment doesn't work with the default 127.0.0.1 address, so this needs to be set in the `app.json` file.